### PR TITLE
Fixing documentation step on pushing to Maven local

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The library can be added to your web app to capture metrics about how it's perfo
 `./gradlew build`
 
 ## Publish to a Maven local repositoty
-`gradle publishToMavenLocal`
+`./gradlew publishToMavenLocal`
 
 ## Adding the library to your project
 


### PR DESCRIPTION
In the documentation, `gradle` is installed via `gradlew`. That does not
install `gradle` globally.
Thus, running `gradle publishToMavenLocal` will result in a
command-not-found error.