### PR TITLE
move to alphagov bintray repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,9 +20,9 @@ bintray {
     configurations = ['archives']
 
     pkg {
-        repo = 'gds_metrics_dropwizard'
-        name = 'gds_metrics_dropwizard'
-        userOrg = 'reliability-engineering-gds'
+        repo = 'maven'
+        name = 'gds-metrics-dropwizard'
+        userOrg = 'alphagov'
         licenses = ['MIT']
         vcsUrl = 'https://github.com/alphagov/gds_metrics_dropwizard.git'
         version {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'gds_metrics_dropwizard'
+rootProject.name = 'gds-metrics-dropwizard'


### PR DESCRIPTION
I've already published the current version to this bintray repo.  PR is more for visibility than anything else.