### PR TITLE
expose InstrumentedAppender to consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,28 @@ $ cf set-env your-app-name ENABLE_DROPWIZARD_METRICS true
 
 Where `your-app-name` is the name of your app.
 
+## Adding logging metrics
+
+To record how many log lines you are emitting, add an appender of type `instrumented` to your config.yaml:
+
+```yaml
+logging:
+  # <... logging configuration ...>
+  appenders:
+    # <... other appenders go here>
+    - type: instrumented
+```
+
+This will add a metric named `logback_appender_total` which records the total number of log messages at each logging level.  For example:
+
+```
+logback_appender_total{level="debug",} 0.0
+logback_appender_total{level="warn",} 1.0
+logback_appender_total{level="trace",} 0.0
+logback_appender_total{level="error",} 0.0
+logback_appender_total{level="info",} 14.0
+```
+
 ## How to configure custom metrics
 
 While common metrics are recorded by default, you can also:

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ dependencies {
     api 'io.prometheus:simpleclient_dropwizard:0.2.0'
     api 'io.prometheus:simpleclient_servlet:0.2.0'
     api 'io.prometheus:simpleclient_hotspot:0.2.0'
+    api 'io.prometheus:simpleclient_logback:0.2.0'
 
     implementation 'com.google.code.gson:gson:2.8.2'
     implementation 'org.glassfish.jersey.core:jersey-client:2.25.1'

--- a/src/main/java/engineering/reliability/gds/metrics/logging/InstrumentedAppenderFactory.java
+++ b/src/main/java/engineering/reliability/gds/metrics/logging/InstrumentedAppenderFactory.java
@@ -1,0 +1,44 @@
+package engineering.reliability.gds.metrics.logging;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.helpers.NOPAppender;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.dropwizard.logging.AbstractAppenderFactory;
+import io.dropwizard.logging.async.AsyncAppenderFactory;
+import io.dropwizard.logging.filter.LevelFilterFactory;
+import io.dropwizard.logging.layout.LayoutFactory;
+import io.prometheus.client.logback.InstrumentedAppender;
+
+@JsonTypeName("instrumented")
+public class InstrumentedAppenderFactory extends AbstractAppenderFactory<ILoggingEvent> {
+
+    @JsonProperty
+    private boolean enabled = true;
+
+    @Override
+    public Appender<ILoggingEvent> build(LoggerContext context,
+                                         String applicationName,
+                                         LayoutFactory<ILoggingEvent> layoutFactory,
+                                         LevelFilterFactory<ILoggingEvent> levelFilterFactory,
+                                         AsyncAppenderFactory<ILoggingEvent> asyncAppenderFactory) {
+        if (!enabled) {
+            final Appender<ILoggingEvent> appender = new NOPAppender<>();
+            appender.start();
+            return appender;
+        }
+
+        final InstrumentedAppender appender = new InstrumentedAppender();
+
+        appender.setContext(context);
+        appender.setName("prometheus-instrumented-appender");
+
+        appender.addFilter(levelFilterFactory.build(threshold));
+        getFilterFactories().forEach(f -> appender.addFilter(f.build()));
+        appender.start();
+
+        return wrapAsync(appender, asyncAppenderFactory);
+    }
+}

--- a/src/main/resources/META-INF/services/io.dropwizard.logging.AppenderFactory
+++ b/src/main/resources/META-INF/services/io.dropwizard.logging.AppenderFactory
@@ -1,0 +1,1 @@
+engineering.reliability.gds.metrics.logging.InstrumentedAppenderFactory


### PR DESCRIPTION
This allows users to instrument how often they are logging at each log
level.  The README documents what has specifically been added.

I don't know if we actually want to provide this: I added it purely to see what InstrumentedAppender (provided by the underlying client_java library) does.  It looks like it might have some value -- you can see where there's spikes in ERRORs or WARNINGs, perhaps -- but it's not broken down by logger name or controller or anything.  I'd be interested to hear other people's views.