### PR TITLE
Add prometheus bundle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'maven-publish'
 apply plugin: 'maven'
 
 group = 'engineering.gds-reliability'
-version = '0.0.1'
+version = '0.0.2'
 
 description = ' Library for prometheus instrumentation in Dropwizard based apps.'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Mon Feb 12 08:29:58 GMT 2018
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4.1-all.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/engineering/reliability/gds/metrics/bundle/MetricsBundle.java
+++ b/src/main/java/engineering/reliability/gds/metrics/bundle/MetricsBundle.java
@@ -3,25 +3,34 @@ package engineering.reliability.gds.metrics.bundle;
 import com.codahale.metrics.MetricRegistry;
 import engineering.reliability.gds.metrics.config.Configuration;
 import engineering.reliability.gds.metrics.filter.AuthenticationFilter;
-import engineering.reliability.gds.metrics.filter.RequestDurationFilter;
 import engineering.reliability.gds.metrics.filter.RequestCountFilter;
+import engineering.reliability.gds.metrics.filter.RequestDurationFilter;
 import io.dropwizard.Bundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.dropwizard.DropwizardExports;
 import io.prometheus.client.exporter.MetricsServlet;
-import io.prometheus.client.hotspot.ClassLoadingExports;
-import io.prometheus.client.hotspot.GarbageCollectorExports;
-import io.prometheus.client.hotspot.MemoryPoolsExports;
-import io.prometheus.client.hotspot.StandardExports;
-import io.prometheus.client.hotspot.ThreadExports;
-import io.prometheus.client.hotspot.VersionInfoExports;
+import io.prometheus.client.hotspot.DefaultExports;
 
 import javax.servlet.DispatcherType;
 import javax.servlet.Filter;
 import java.util.EnumSet;
 
+/**
+ * MetricsBundle
+ *
+ * This is a Dropwizard bundle that adds prometheus instrumentation to a dropwizard app. in particular:
+ * <ul>
+ *  <li> it registers the dropwizard metrics (ie com.codahale.metrics metrics) with the prometheus registry
+ *  <li> it registers the {@link DefaultExports} with the prometheus registry
+ *  <li> it adds {@link RequestCountFilter} to record a count of requests by code, path, host, and method
+ *  <li> it adds {@link RequestDurationFilter} to record a histogram of request durations by code, path, host, and method
+ *  <li> it registers a prometheus {@link MetricsServlet} to serve metrics on /metrics (or wherever configured) on the app port
+ *    <li> it adds {@link AuthenticationFilter} to ensure requests to the metrics endpoint based on the application_id
+ *      in the VCAP_APPLICATION environment variable
+ * </ul>
+ */
 public class MetricsBundle implements Bundle {
 
 	final Configuration configuration = Configuration.getInstance();
@@ -35,12 +44,7 @@ public class MetricsBundle implements Bundle {
 			CollectorRegistry.defaultRegistry.register(new DropwizardExports(metrics));
 		}
 
-		CollectorRegistry.defaultRegistry.register(new ClassLoadingExports());
-		CollectorRegistry.defaultRegistry.register(new GarbageCollectorExports());
-		CollectorRegistry.defaultRegistry.register(new MemoryPoolsExports());
-		CollectorRegistry.defaultRegistry.register(new StandardExports());
-		CollectorRegistry.defaultRegistry.register(new ThreadExports());
-		CollectorRegistry.defaultRegistry.register(new VersionInfoExports());
+		DefaultExports.initialize();
 	}
 
 	@Override

--- a/src/main/java/engineering/reliability/gds/metrics/bundle/PrometheusBundle.java
+++ b/src/main/java/engineering/reliability/gds/metrics/bundle/PrometheusBundle.java
@@ -1,0 +1,111 @@
+package engineering.reliability.gds.metrics.bundle;
+
+
+import com.codahale.metrics.*;
+import engineering.reliability.gds.metrics.config.PrometheusConfiguration;
+import io.dropwizard.ConfiguredBundle;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.dropwizard.DropwizardExports;
+import io.prometheus.client.exporter.MetricsServlet;
+import io.prometheus.client.hotspot.DefaultExports;
+
+import java.util.SortedMap;
+
+
+/**
+ * PrometheusBundle
+ *
+ * This is a Dropwizard bundle that adds prometheus instrumentation to a dropwizard app. in particular:
+ * <ul>
+ *  <li>it registers the dropwizard metrics (ie com.codahale.metrics metrics) with the prometheus registry
+ *  <li>it registers the {@link DefaultExports} with the prometheus registry
+ *  <li>it registers a prometheus {@link MetricsServlet} to serve metrics on /prometheus/metrics on the admin port
+ * </ul>
+ *
+ * Differences between this and {@link MetricsBundle}:
+ * <ul>
+ *  <li> PrometheusBundle listens on admin port, MetricsBundle listens on app port
+ *    <li> PrometheusBundle therefore doesn't need {@link engineering.reliability.gds.metrics.filter.AuthenticationFilter}
+ *  <li> PrometheusBundle filters out jvm.* dropwizard metrics
+ *  <li> PrometheusBundle doesn't assume you want {@link engineering.reliability.gds.metrics.filter.RequestCountFilter} or
+ *    {@link engineering.reliability.gds.metrics.filter.RequestDurationFilter}
+ *  <li> MetricsBundle uses its own magic configuration in {@link engineering.reliability.gds.metrics.config.Configuration},
+ *    PrometheusBundle uses {@link ConfiguredBundle} to have configuration injected in a more dropwizard-native way
+ * </ul>
+ *
+ * Longer term, I think we should not have two separate bundles, and instead find a way to merge the functionality
+ * into one.  For the moment, though, I want something simple that can be used by Verify.
+ */
+public class PrometheusBundle implements ConfiguredBundle<PrometheusConfiguration> {
+    @Override
+    public void initialize(Bootstrap<?> bootstrap) {
+    }
+
+    @Override
+    public void run(PrometheusConfiguration configuration, Environment environment) {
+        if (configuration.isPrometheusEnabled()) {
+            DefaultExports.initialize();
+            MetricRegistry metrics = new FilteredMetricRegistryView(environment.metrics(), this::isNotJvmMetric);
+            CollectorRegistry.defaultRegistry.register(new DropwizardExports(metrics));
+            environment.admin().addServlet("metrics", new MetricsServlet())
+                    .addMapping("/prometheus/metrics");
+        }
+    }
+
+    /**
+     * There are a number of dropwizard metrics that start with <code>jvm.*</code>.
+     * These are confusing because, after sanitizing dots to underscores, they end up in the same namespace as
+     * prometheus <code>jvm_*</code> metrics, and in most cases they duplicate something that already exists in
+     * prometheus.
+     * For example: the dropwizard metric <code>jvm.threads.daemon.count</code> will have its name converted to
+     * <code>jvm_threads_daemon_count</code>, but it duplicates the existing prometheus metric
+     * <code>jvm_threads_daemon</code>.
+     *
+     * Easiest is just to remove all the dropwizard <code>jvm.*</code> metrics with this filter.
+     */
+    private boolean isNotJvmMetric(String name, Metric metric) {
+        return !name.startsWith("jvm.");
+    }
+
+    /**
+     * This class wraps a MetricRegistry but only presents a subset of the metrics to the caller
+     * We use it to present only certain metrics to the Prometheus CollectorRegistry using
+     * filters like isNotJvmMetric above.
+     */
+    private static class FilteredMetricRegistryView extends MetricRegistry {
+        private MetricRegistry metrics;
+        private MetricFilter filter;
+
+        private FilteredMetricRegistryView(MetricRegistry metrics, MetricFilter filter) {
+            this.metrics = metrics;
+            this.filter = filter;
+        }
+
+        @Override
+        public SortedMap<String, Gauge> getGauges() {
+            return metrics.getGauges(filter);
+        }
+
+        @Override
+        public SortedMap<String, Counter> getCounters() {
+            return metrics.getCounters(filter);
+        }
+
+        @Override
+        public SortedMap<String, Histogram> getHistograms() {
+            return metrics.getHistograms(filter);
+        }
+
+        @Override
+        public SortedMap<String, Meter> getMeters() {
+            return metrics.getMeters(filter);
+        }
+
+        @Override
+        public SortedMap<String, Timer> getTimers() {
+            return metrics.getTimers(filter);
+        }
+    }
+}

--- a/src/main/java/engineering/reliability/gds/metrics/config/PrometheusConfiguration.java
+++ b/src/main/java/engineering/reliability/gds/metrics/config/PrometheusConfiguration.java
@@ -1,0 +1,5 @@
+package engineering.reliability.gds.metrics.config;
+
+public interface PrometheusConfiguration {
+    boolean isPrometheusEnabled();
+}


### PR DESCRIPTION
This adds a PrometheusBundle and tidies up the old MetricsBundle.

The MetricsBundle was created in the mists of time and was a proof of concept for how paas apps can be instrumented.  For instrumenting Verify, I thought it was wise to start from a clean slate and not reuse MetricsBundle.

I think in the long term we should standardize on PrometheusBundle and move away from MetricsBundle, but not just yet.