### PR TITLE
 Change deployment so that travis deploys to bintray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,17 @@
 language: java
 cache:
   directories:
-  - $HOME/.gradle/caches
-  - $HOME/.gradle/wrapper
-  - $HOME/.m2
+  - "$HOME/.gradle/caches"
+  - "$HOME/.gradle/wrapper"
+  - "$HOME/.m2"
 jdk:
 - oraclejdk8
+deploy:
+  provider: script
+  script: bash scripts/travis_deploy.sh
+  on:
+    tags: true
+env:
+  global:
+  - BINTRAY_USER=philippotter
+  - secure: xPZ4jTKfFGXTLHf9ARUrXLTrcbpIe3XK8hrOEohSIjCHvHbEGgGKCm4qusVLbzDdWi2LW3wsd9Tk1LWIYk3UToXRQ+NJDYM+ZzOIbGUon4kFLlskeKeb8Z8QqnpOwtrREQ9y7N5bj2WtzwXKzOo0msdSgs/eZm5X5BbZZRZxpEH/JILuWNyG3Kw/31+f1yxnPQ95Q58K1HmjwAAAGF9cJ4UxvjIlP0sU+oK6SQaUf+6V57fWn/Mp5X4+rg29YxJUnV8RWxMaTyYPeSpfDyTgiCDYHrSoWAZUAKH/BGC3tKueOK/DOEDAib/+5h97SzXfhEFAaeaxvwlan82vCK8S9TGkvD1PRECubi4sBsx+c5DEp71Jzk41ZzAzLGP/m3K/DhZSX/TObgMDTTCsRYZoDtxnd/RP+8EAl68nEvpDA+DkG/5EKlHLU8wsppLIDxhz77mHxbgnWT5u50DgRm3VjgQQ3soL/N4tYyWV5yrmUA4zhNUN0Y8BMNsGWjFm//1AfmsL/jq/CMw15kqMQm06SjoRR2joYFTxSOjzENH/VNE/NOrub4bxX5UoOSlNY6NCd2GUe77jhzB7HNdvLeafSALCISSfvQuY1+TJ94xQ/TtVjR3S+/inGS/PtujWPOC1BKyBT9wjgb+hLBMXELmJ5p3LqTiPI1vAvzFyk8QGlO8=

--- a/README.md
+++ b/README.md
@@ -123,6 +123,16 @@ You can read more about the different types of metrics available in the [Prometh
 
 GDS Reliability Engineering welcome contributions. We'd appreciate it if you write tests with your changes and document them where appropriate, this will help us review them quickly.
 
+## Releasing a new version
+
+To release a new version:
+
+ - bump the version in gradle.properties and the dependencies in the README
+   and commit
+ - tag with the new version number and push the tag (eg `git tag 0.1.3; git push --tags`)
+ - travis will build and deploy the new version to bintray
+ - bump the version in gradle.properties to the next SNAPSHOT (eg `0.1.3-SNAPSHOT`)
+
 ## Licence
 
 This project is licensed under the [MIT License][].

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,6 @@ apply plugin: 'maven-publish'
 apply plugin: 'maven'
 
 group = 'engineering.gds-reliability'
-version = '0.0.2'
 
 description = ' Library for prometheus instrumentation in Dropwizard based apps.'
 
@@ -29,9 +28,6 @@ bintray {
         userOrg = 'alphagov'
         licenses = ['MIT']
         vcsUrl = 'https://github.com/alphagov/gds_metrics_dropwizard.git'
-        version {
-            name = '0.0.1'
-        }
     }
 }
 
@@ -62,7 +58,6 @@ jar {
     }
 
     baseName = 'gds-metrics-dropwizard'
-    version = '0.0.1'
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "com.jfrog.bintray" version "1.7.3"
+    id "com.jfrog.bintray" version "1.8.4"
 }
 
 repositories {
@@ -19,8 +19,8 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 bintray {
-    user = System.getenv('BINTRAY_USER')
-    key = System.getenv('BINTRAY_KEY')
+    user = System.env.BINTRAY_USER
+    key = System.env.BINTRAY_KEY
     configurations = ['archives']
 
     pkg {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+version=0.0.2-SNAPSHOT

--- a/scripts/travis_deploy.sh
+++ b/scripts/travis_deploy.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -ue
+
+GRADLE_VERSION=$(./gradlew properties | grep version | awk '{ print $2 }')
+
+if [ $TRAVIS_TAG != $GRADLE_VERSION ]; then
+    echo tag $TRAVIS_TAG disagrees with gradle version $GRADLE_VERSION. aborting
+    exit 1
+fi
+
+./gradlew bintrayUpload


### PR DESCRIPTION
This allows travis to deploy to bintray.

The README explains how it should work - you tag a release and push it
to cause travis to actually deploy.  Travis checks to make sure the
git tag matches the checked-in version in gradle.properties.

We could in future look in to using something like
https://github.com/researchgate/gradle-release to automate the release
process, but this commit is the first step towards an automated CI
build.