### PR TITLE
bump dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ cache:
   - "$HOME/.gradle/wrapper"
   - "$HOME/.m2"
 jdk:
-- oraclejdk8
 - openjdk11
 deploy:
   provider: script

--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,8 @@ group = 'engineering.gds-reliability'
 
 description = ' Library for prometheus instrumentation in Dropwizard based apps.'
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 1.11
+targetCompatibility = 1.11
 
 bintray {
     user = System.env.BINTRAY_USER
@@ -62,18 +62,18 @@ jar {
 }
 
 def dependencyVersions = [
-        dropwizard: '1.3.5',
-        mockito: '2.23.0',
+        dropwizard: '1.3.14',
+        mockito: '2.28.2',
         ]
 
 dependencies {
-    api 'io.prometheus:simpleclient_dropwizard:0.2.0'
-    api 'io.prometheus:simpleclient_servlet:0.2.0'
-    api 'io.prometheus:simpleclient_hotspot:0.2.0'
+    api 'io.prometheus:simpleclient_dropwizard:0.7.0'
+    api 'io.prometheus:simpleclient_servlet:0.7.0'
+    api 'io.prometheus:simpleclient_hotspot:0.7.0'
 
-    implementation 'com.google.code.gson:gson:2.8.2'
+    implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'org.glassfish.jersey.core:jersey-client:2.25.1'
-    implementation'javax.servlet:javax.servlet-api:3.1.0'
+    implementation'javax.servlet:javax.servlet-api:4.0.1'
 
     compileOnly 'io.dropwizard:dropwizard-core:'+dependencyVersions.dropwizard
 


### PR DESCRIPTION
Bump versions:

 - Java 8 -> 11
 - Dropwizard 1.3.5 -> 1.3.14
 - prometheus client_java 0.2.0 -> 0.7.0
 - and gson and servlet-api

I tried bumping jersey to 2.29.1 but that caused weird breakages.  So
I thought we could at least get this much done.