### PR TITLE
G34uCPYu: add Dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,10 @@
+version: 1
+update_configs:
+  - package_manager: "java:gradle"
+    directory: "/"
+    update_schedule: "daily"
+    default_labels:
+      - "dependabot"
+    target_branch: "master"
+    commit_message:
+      prefix: "BAU"


### PR DESCRIPTION
We want to make sure we keep our dependencies up to date. This will reduce our exposure to potential security vulnerabilities and let us fix them more quickly.

We use Dependabot for this, following the other DCS-related repositories.

We need to use the old version (1) because the new version doesn't yet support Gradle.