### PR TITLE
G34uCPYu: use Gradle variables for versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,10 +61,10 @@ jar {
     baseName = 'gds-metrics-dropwizard'
 }
 
-def dependencyVersions = [
-        dropwizard: '1.3.14',
-        mockito: '2.28.2',
-        ]
+ext {
+    dropwizard_version = '1.3.14'
+    mockito_version = '2.28.2'
+}
 
 dependencies {
     api 'io.prometheus:simpleclient_dropwizard:0.9.0'
@@ -75,11 +75,11 @@ dependencies {
     implementation 'org.glassfish.jersey.core:jersey-client:2.25.1'
     implementation'javax.servlet:javax.servlet-api:4.0.1'
 
-    compileOnly 'io.dropwizard:dropwizard-core:'+dependencyVersions.dropwizard
+    compileOnly 'io.dropwizard:dropwizard-core:'+dropwizard_version
 
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:'+dependencyVersions.mockito
-    testImplementation 'io.dropwizard:dropwizard-testing:'+dependencyVersions.dropwizard
+    testImplementation 'org.mockito:mockito-core:'+mockito_version
+    testImplementation 'io.dropwizard:dropwizard-testing:'+dropwizard_version
 }
 
 publishing {


### PR DESCRIPTION
Dependabot can't deal with versions being stored in hashmaps, but can cope with them being in variables. I think this should give Dependabot visibility of the versions.