### PR TITLE
BAU: ignore Dropwizard 2

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -8,3 +8,7 @@ update_configs:
     target_branch: "master"
     commit_message:
       prefix: "BAU"
+    ignored_updates:
+      - match:
+          dependency_name: "io.dropwizard:*"
+          version_requirement: "2.+"


### PR DESCRIPTION
All the projects that use this are still using Dropwizard 1.x. Thus, we should be testing with Dropwizard 1.x.