### PR TITLE
G34uCPYu: use dependency variable interpolation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,11 +75,11 @@ dependencies {
     implementation 'org.glassfish.jersey.core:jersey-client:2.25.1'
     implementation'javax.servlet:javax.servlet-api:4.0.1'
 
-    compileOnly 'io.dropwizard:dropwizard-core:'+dropwizard_version
+    compileOnly "io.dropwizard:dropwizard-core:$dropwizard_version"
 
     testImplementation 'junit:junit:4.13'
-    testImplementation 'org.mockito:mockito-core:'+mockito_version
-    testImplementation 'io.dropwizard:dropwizard-testing:'+dropwizard_version
+    testImplementation "org.mockito:mockito-core:$mockito_version"
+    testImplementation "io.dropwizard:dropwizard-testing:$dropwizard_version"
 }
 
 publishing {


### PR DESCRIPTION
It seems as if Dependabot doesn't recognise dependencies when we concatenate the variable containing the version number. Let's try using interpolation instead - we did this for another repo and it worked. If this works, we should expect to see a PR to update the version of Dropwizard.