### PR TITLE
JUM15Qak: ignore updates to jersey-client

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -12,3 +12,7 @@ update_configs:
       - match:
           dependency_name: "io.dropwizard:*"
           version_requirement: "2.+"
+      - match:
+          # We currently use the latest version supported by Dropwizard v1, so cannot upgrade
+          dependency_name: "org.glassfish.jersey.core:jersey-client"
+          version_requirement: "+"


### PR DESCRIPTION
v2.25.1 is the last version supported by Dropwizard 1 (see https://github.com/dropwizard/dropwizard/issues/2148). So we cannot upgrade until we upgrade Dropwizard itself.