### PR TITLE
Hub 866 publish gds metrics dropwizard to maven

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,40 +18,20 @@ Before using GDS metrics you should have:
 
 ## How to build your project
 
-1. Add the GDS metrics library to where your project is stored by adding:
-
-    Maven
-    ```
-    <repositories>
-        <repository>
-            <id>reliability-engineering-repository</id>
-            <name>Repository containing reliability engineering dependencies</name>
-            <url>https://dl.bintray.com/alphagov/maven</url>
-        </repository>
-    </repositories>
-    ```
-
-    Gradle
-    ```
-    repositories {
-        maven { url "https://dl.bintray.com/alphagov/maven" }
-    }
-    ```
-
-2. Add your library as a dependency to your project.
+Add your library as a dependency to your project.
 
     Maven
     ```
     <dependency>
-        <groupId>engineering.gds-reliability</groupId>
+        <groupId>uk.gov.ida</groupId>
         <artifactId>gds-metrics-dropwizard</artifactId>
-        <version>0.2.0</version>
+        <version>0.7.0</version>
     </dependency>
     ```
 
     Gradle
     ```
-    implementation 'engineering.gds-reliability:gds-metrics-dropwizard:0.2.0'
+    implementation 'uk.gov.ida:gds-metrics-dropwizard:0.7.0'
     ```
 
 The metrics will be exposed at the path /prometheus/metrics on the admin port.

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "com.jfrog.bintray" version "1.8.5"
+    id "io.github.gradle-nexus.publish-plugin" version "1.0.0"
 }
 
 repositories {
@@ -8,29 +8,14 @@ repositories {
 
 apply plugin: 'java-library'
 apply plugin: 'maven-publish'
+apply plugin: 'signing'
 apply plugin: 'maven'
-
-group = 'engineering.gds-reliability'
+apply plugin: 'io.github.gradle-nexus.publish-plugin'
 
 description = ' Library for prometheus instrumentation in Dropwizard based apps.'
 
 sourceCompatibility = 1.11
 targetCompatibility = 1.11
-
-bintray {
-    user = System.env.BINTRAY_USER
-    key = System.env.BINTRAY_KEY
-    configurations = ['archives']
-    publish = true
-
-    pkg {
-        repo = 'maven'
-        name = 'gds-metrics-dropwizard'
-        userOrg = 'alphagov'
-        licenses = ['MIT']
-        vcsUrl = 'https://github.com/alphagov/gds_metrics_dropwizard.git'
-    }
-}
 
 test {
     dependsOn << compileTestJava
@@ -82,10 +67,69 @@ dependencies {
     testImplementation "io.dropwizard:dropwizard-testing:$dropwizard_version"
 }
 
+java {
+    withJavadocJar()
+    withSourcesJar()
+}
+
+nexusPublishing {
+    useStaging = true
+    repositories {
+        sonatype {
+            // because we registered in Sonatype after 24 Feb 2021, we provide these URIs
+            // see: https://github.com/gradle-nexus/publish-plugin/blob/master/README.md
+            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+            username = System.getenv("SONATYPE_USERNAME")
+            password = System.getenv("SONATYPE_PASSWORD")
+        }
+    }
+}
+
+signing {
+    useInMemoryPgpKeys(
+            System.getenv("MAVEN_CENTRAL_SIGNING_KEY"),
+            System.getenv("MAVEN_CENTRAL_SIGNING_KEY_PASSWORD")
+    )
+    sign publishing.publications
+}
+
+def buildVersion = "0.7.0-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
+group = 'uk.gov.ida'
+version = "$buildVersion"
+
 publishing {
     publications {
         mavenJava(MavenPublication) {
             from components.java
+            groupId = 'uk.gov.ida'
+            pom {
+                name = 'gds_metrics_dropwizard'
+                packaging = 'jar'
+                description = 'Library for gds metrics dropwizard operations.'
+                url = 'https://github.com/alphagov/gds_metrics_dropwizard'
+                artifactId = 'gds_metrics_dropwizard'
+
+                scm {
+                    url = 'https://github.com/alphagov/gds_metrics_dropwizard'
+                    connection = 'scm:git:git://github.com/alphagov/gds_metrics_dropwizard.git'
+                    developerConnection = 'scm:git:ssh://git@github.com:alphagov/gds_metrics_dropwizard.git'
+                }
+
+                licenses {
+                    license {
+                        name = 'MIT Licence'
+                        url = 'https://github.com/alphagov/gds_metrics_dropwizard/blob/master/LICENSE'
+                        distribution = 'repo'
+                    }
+                }
+
+                developers {
+                    developer {
+                        name = 'GDS Developers'
+                    }
+                }
+            } // pom
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,6 @@ repositories {
 apply plugin: 'java-library'
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
-apply plugin: 'maven'
 apply plugin: 'io.github.gradle-nexus.publish-plugin'
 
 description = ' Library for prometheus instrumentation in Dropwizard based apps.'
@@ -102,7 +101,7 @@ publishing {
     publications {
         mavenJava(MavenPublication) {
             from components.java
-            groupId = 'uk.gov.ida'
+            groupId = group
             pom {
                 name = 'gds_metrics_dropwizard'
                 packaging = 'jar'

--- a/src/main/java/uk/gov/ida/metrics/bundle/PrometheusBundle.java
+++ b/src/main/java/uk/gov/ida/metrics/bundle/PrometheusBundle.java
@@ -1,14 +1,7 @@
-package engineering.reliability.gds.metrics.bundle;
+package uk.gov.ida.metrics.bundle;
 
-import com.codahale.metrics.Counter;
-import com.codahale.metrics.Gauge;
-import com.codahale.metrics.Histogram;
-import com.codahale.metrics.Meter;
 import com.codahale.metrics.Metric;
-import com.codahale.metrics.MetricFilter;
-import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.Timer;
-import engineering.reliability.gds.metrics.config.PrometheusConfiguration;
+import uk.gov.ida.metrics.config.PrometheusConfiguration;
 import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
@@ -16,8 +9,6 @@ import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.dropwizard.DropwizardExports;
 import io.prometheus.client.exporter.MetricsServlet;
 import io.prometheus.client.hotspot.DefaultExports;
-
-import java.util.SortedMap;
 
 /**
  * PrometheusBundle

--- a/src/main/java/uk/gov/ida/metrics/config/PrometheusConfiguration.java
+++ b/src/main/java/uk/gov/ida/metrics/config/PrometheusConfiguration.java
@@ -1,4 +1,4 @@
-package engineering.reliability.gds.metrics.config;
+package uk.gov.ida.metrics.config;
 
 public interface PrometheusConfiguration {
     boolean isPrometheusEnabled();

--- a/src/main/java/uk/gov/ida/metrics/utils/EnvVarUtils.java
+++ b/src/main/java/uk/gov/ida/metrics/utils/EnvVarUtils.java
@@ -1,4 +1,4 @@
-package engineering.reliability.gds.metrics.utils;
+package uk.gov.ida.metrics.utils;
 
 public class EnvVarUtils {
 

--- a/src/main/java/uk/gov/ida/metrics/utils/StringUtils.java
+++ b/src/main/java/uk/gov/ida/metrics/utils/StringUtils.java
@@ -1,4 +1,4 @@
-package engineering.reliability.gds.metrics.utils;
+package uk.gov.ida.metrics.utils;
 
 import java.util.Objects;
 

--- a/src/test/java/engineering/reliability/gds/metrics/support/TestApplication.java
+++ b/src/test/java/engineering/reliability/gds/metrics/support/TestApplication.java
@@ -1,6 +1,6 @@
 package engineering.reliability.gds.metrics.support;
 
-import engineering.reliability.gds.metrics.bundle.PrometheusBundle;
+import uk.gov.ida.metrics.bundle.PrometheusBundle;
 import io.dropwizard.Application;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;

--- a/src/test/java/engineering/reliability/gds/metrics/support/TestConfiguration.java
+++ b/src/test/java/engineering/reliability/gds/metrics/support/TestConfiguration.java
@@ -1,7 +1,7 @@
 package engineering.reliability.gds.metrics.support;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import engineering.reliability.gds.metrics.config.PrometheusConfiguration;
+import uk.gov.ida.metrics.config.PrometheusConfiguration;
 import io.dropwizard.Configuration;
 
 import javax.validation.constraints.NotNull;

--- a/src/test/java/uk/gov/ida/metrics/bundle/PrometheusBundleTest.java
+++ b/src/test/java/uk/gov/ida/metrics/bundle/PrometheusBundleTest.java
@@ -1,4 +1,4 @@
-package engineering.reliability.gds.metrics.bundle;
+package uk.gov.ida.metrics.bundle;
 
 import engineering.reliability.gds.metrics.support.TestApplication;
 import engineering.reliability.gds.metrics.support.TestConfiguration;
@@ -11,7 +11,6 @@ import org.junit.Test;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Response;
 
-import static engineering.reliability.gds.metrics.bundle.PrometheusBundle.PROMETHEUS_METRICS_RESOURCE;
 import static engineering.reliability.gds.metrics.support.TestResource.TEST_RESOURCE_PATH;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -33,7 +32,7 @@ public class PrometheusBundleTest {
 
     @Test
     public void aDropwizardResourceTimerMetricIsLogged() {
-        Response response = client.target("http://localhost:" + appRuleWithMetrics.getAdminPort() + PROMETHEUS_METRICS_RESOURCE)
+        Response response = client.target("http://localhost:" + appRuleWithMetrics.getAdminPort() + PrometheusBundle.PROMETHEUS_METRICS_RESOURCE)
                 .request()
                 .get();
         assertThat(response.getStatus()).isEqualTo(200);
@@ -45,7 +44,7 @@ public class PrometheusBundleTest {
         assertThat(response.getStatus()).isEqualTo(200);
         assertThat(response.readEntity(String.class)).isEqualTo("hello");
 
-        response = client.target("http://localhost:" + appRuleWithMetrics.getAdminPort() + PROMETHEUS_METRICS_RESOURCE)
+        response = client.target("http://localhost:" + appRuleWithMetrics.getAdminPort() + PrometheusBundle.PROMETHEUS_METRICS_RESOURCE)
                 .request()
                 .get();
         assertThat(response.getStatus()).isEqualTo(200);
@@ -54,7 +53,7 @@ public class PrometheusBundleTest {
 
     @Test
     public void noDropwizardJvmMetricsAreLogged() {
-        final Response response = client.target("http://localhost:" + appRuleWithMetrics.getAdminPort() + PROMETHEUS_METRICS_RESOURCE)
+        final Response response = client.target("http://localhost:" + appRuleWithMetrics.getAdminPort() + PrometheusBundle.PROMETHEUS_METRICS_RESOURCE)
                 .request()
                 .get();
         assertThat(response.getStatus()).isEqualTo(200);
@@ -67,7 +66,7 @@ public class PrometheusBundleTest {
 
     @Test
     public void metricsAreNotPresentWhenMetricsAreDisabled() {
-        final Response response = client.target("http://localhost:" + appRuleWithoutMetrics.getAdminPort() + PROMETHEUS_METRICS_RESOURCE)
+        final Response response = client.target("http://localhost:" + appRuleWithoutMetrics.getAdminPort() + PrometheusBundle.PROMETHEUS_METRICS_RESOURCE)
                 .request()
                 .get();
         assertThat(response.getStatus()).isEqualTo(404);


### PR DESCRIPTION
It was decided that we should take ownership of this library, it is currently being used by Verify and DCS. It had a package name of `engineering.reliability.gds` this has been changed to match our registered maven group_id `uk.gov.ida`

Have tested this locally and observed the correct files in Sonatype staging repo
