### PR TITLE
BAU: corrected package naming

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ publishing {
                 packaging = 'jar'
                 description = 'Library for gds metrics dropwizard operations.'
                 url = 'https://github.com/alphagov/gds_metrics_dropwizard'
-                artifactId = 'gds_metrics_dropwizard'
+                artifactId = 'gds-metrics-dropwizard'
 
                 scm {
                     url = 'https://github.com/alphagov/gds_metrics_dropwizard'

--- a/src/test/java/uk/gov/ida/metrics/bundle/PrometheusBundleTest.java
+++ b/src/test/java/uk/gov/ida/metrics/bundle/PrometheusBundleTest.java
@@ -1,18 +1,18 @@
 package uk.gov.ida.metrics.bundle;
 
-import engineering.reliability.gds.metrics.support.TestApplication;
-import engineering.reliability.gds.metrics.support.TestConfiguration;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import org.glassfish.jersey.client.JerseyClientBuilder;
 import org.junit.ClassRule;
 import org.junit.Test;
+import uk.gov.ida.metrics.support.TestApplication;
+import uk.gov.ida.metrics.support.TestConfiguration;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Response;
 
-import static engineering.reliability.gds.metrics.support.TestResource.TEST_RESOURCE_PATH;
 import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.ida.metrics.support.TestResource.TEST_RESOURCE_PATH;
 
 public class PrometheusBundleTest {
 
@@ -36,7 +36,7 @@ public class PrometheusBundleTest {
                 .request()
                 .get();
         assertThat(response.getStatus()).isEqualTo(200);
-        assertThat(response.readEntity(String.class)).contains("engineering_reliability_gds_metrics_support_TestResource_get_count 0");
+        assertThat(response.readEntity(String.class)).contains("uk_gov_ida_metrics_support_TestResource_get_count 0");
 
         response = client.target("http://localhost:" + appRuleWithMetrics.getLocalPort() + TEST_RESOURCE_PATH)
                 .request()
@@ -48,7 +48,7 @@ public class PrometheusBundleTest {
                 .request()
                 .get();
         assertThat(response.getStatus()).isEqualTo(200);
-        assertThat(response.readEntity(String.class)).contains("engineering_reliability_gds_metrics_support_TestResource_get_count 1.0");
+        assertThat(response.readEntity(String.class)).contains("uk_gov_ida_metrics_support_TestResource_get_count 1.0");
     }
 
     @Test

--- a/src/test/java/uk/gov/ida/metrics/mock/MockHttpServletRequest.java
+++ b/src/test/java/uk/gov/ida/metrics/mock/MockHttpServletRequest.java
@@ -1,12 +1,31 @@
-package engineering.reliability.gds.metrics.mock;
+package uk.gov.ida.metrics.mock;
 
-import javax.servlet.*;
-import javax.servlet.http.*;
+import javax.servlet.AsyncContext;
+import javax.servlet.DispatcherType;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.ServletInputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpUpgradeHandler;
+import javax.servlet.http.Part;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.Principal;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
 
 public class MockHttpServletRequest implements HttpServletRequest {
 

--- a/src/test/java/uk/gov/ida/metrics/mock/MockHttpServletResponse.java
+++ b/src/test/java/uk/gov/ida/metrics/mock/MockHttpServletResponse.java
@@ -1,4 +1,4 @@
-package engineering.reliability.gds.metrics.mock;
+package uk.gov.ida.metrics.mock;
 
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.Cookie;

--- a/src/test/java/uk/gov/ida/metrics/support/TestApplication.java
+++ b/src/test/java/uk/gov/ida/metrics/support/TestApplication.java
@@ -1,4 +1,4 @@
-package engineering.reliability.gds.metrics.support;
+package uk.gov.ida.metrics.support;
 
 import uk.gov.ida.metrics.bundle.PrometheusBundle;
 import io.dropwizard.Application;

--- a/src/test/java/uk/gov/ida/metrics/support/TestConfiguration.java
+++ b/src/test/java/uk/gov/ida/metrics/support/TestConfiguration.java
@@ -1,4 +1,4 @@
-package engineering.reliability.gds.metrics.support;
+package uk.gov.ida.metrics.support;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.ida.metrics.config.PrometheusConfiguration;

--- a/src/test/java/uk/gov/ida/metrics/support/TestResource.java
+++ b/src/test/java/uk/gov/ida/metrics/support/TestResource.java
@@ -1,13 +1,11 @@
-package engineering.reliability.gds.metrics.support;
+package uk.gov.ida.metrics.support;
 
 import com.codahale.metrics.annotation.Timed;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
-import static engineering.reliability.gds.metrics.support.TestResource.TEST_RESOURCE_PATH;
-
-@Path(TEST_RESOURCE_PATH)
+@Path(TestResource.TEST_RESOURCE_PATH)
 public class TestResource {
 
     public static final String TEST_RESOURCE_PATH = "/";


### PR DESCRIPTION
Some of the test classes package names were missed, so changed to new
package name uk.gov.ida also changed the artifateId from gds_metrics_dropwizard
to gds-metrics-dropwizard

Also straight out some import.* to use explicit imports